### PR TITLE
Fix last_pose bug in nuscenes_converter.py

### DIFF
--- a/docs/can_bus.ipynb
+++ b/docs/can_bus.ipynb
@@ -125,7 +125,7 @@
     "    can_bus.extend(rotation) # [3:7] is the orientation\n",
     "    \n",
     "    for key in last_pose.keys():\n",
-    "        can_bus.extend(pose[key])  # accel: [7, 10], rotation_rate: [10: 13], velocity: [13: 16]\n",
+    "        can_bus.extend(last_pose[key])  # accel: [7, 10], rotation_rate: [10: 13], velocity: [13: 16]\n",
     "    \n",
     "    # the last two numbers are reserved for later calculation of rotation angle.\n",
     "    can_bus.extend([0., 0.])\n",

--- a/tools/data_converter/nuscenes_converter.py
+++ b/tools/data_converter/nuscenes_converter.py
@@ -171,7 +171,7 @@ def _get_can_bus_info(nusc, nusc_can_bus, sample):
     can_bus.extend(pos)
     can_bus.extend(rotation)
     for key in last_pose.keys():
-        can_bus.extend(pose[key])  # 16 elements
+        can_bus.extend(last_pose[key])  # 16 elements
     can_bus.extend([0., 0.])
     return np.array(can_bus)
 


### PR DESCRIPTION
Thanks for this amazing work! I got into a little trouble when reading can_bus data using `nuscenes_converter.py` .
After I checked, I noticed that there was a small bug in this script. 
as you can see , the `vel` ,  `velocity`  and `rotation_rate` are one frame lagging

``` python
data = pickle.load(open(<pkl_path>, 'rb') as f)
data['infos']['scene-0003'][1]['can_bus']
>>>
array([ 2.49872966e+02,  9.17558592e+02,  0.00000000e+00,  9.98390395e-01,
        0.00000000e+00,  0.00000000e+00, -5.67152390e-02, -8.88715231e-03,
       -3.97558906e-01,  9.80574822e+00, -7.58608920e-04,  4.25659760e-04,
       -3.16689089e-02,  8.12085215e-08,  0.00000000e+00,  0.00000000e+00,
        0.00000000e+00,  0.00000000e+00])
```
However , you will find that the raw data in `nuscenes/can_bus/scene-0003_pose.json` looks like this:
```json
[
...

    {
        "accel": [
            -0.02809354193250988,
            -0.39169555596793926,
            9.776298785696437
        ],
        "orientation": [
            0.9983903954177029,
            0.0,
            0.0,
            -0.056715239025175467
        ],
        "pos": [
            249.87296600685508,
            917.5585920742254,
            0.0
        ],
        "rotation_rate": [
            -0.0013980914372950792,
            -0.0021305647678673267,
            -0.03170059993863106
        ],
        "utime": 1533201470937524,
        "vel": [
            1.225028636241502e-07,
            0.0,
            0.0
        ]
    },
    {
        "accel": [
            -0.00888715230771263,
            -0.39755890555260953,
            9.805748215542922
        ],
        "orientation": [
            0.998388355813101,
            0.0,
            0.0,
            -0.0567511319430092
        ],
        "pos": [
            249.87279020125354,
            917.5587293410829,
            0.0
        ],
        "rotation_rate": [
            -0.0007586089195683599,
            0.00042565976036712527,
            -0.03166890889406204
        ],
        "utime": 1533201470957393,
        "vel": [
            8.120852151007131e-08,
            0.0,
            0.0
        ]
    },
...
]

```
the `pos` and `orientation` come from the former, but the rest of them come from the latter.
I assume that this won't be a big problem since those two frames are quite close.


